### PR TITLE
Add parameter noise to ddpg

### DIFF
--- a/ddpg.py
+++ b/ddpg.py
@@ -17,67 +17,75 @@ def hard_update(target, source):
     for target_param, param in zip(target.parameters(), source.parameters()):
         target_param.data.copy_(param.data)
 
+"""
+From: https://github.com/pytorch/pytorch/issues/1959
+There's an official LayerNorm implementation in pytorch now, but it hasn't been included in 
+pip version yet. This is a temporary version
+This slows down training by a bit
+"""
+class LayerNorm(nn.Module):
+    def __init__(self, num_features, eps=1e-5, affine=True):
+        super(LayerNorm, self).__init__()
+        self.num_features = num_features
+        self.affine = affine
+        self.eps = eps
+
+        if self.affine:
+            self.gamma = nn.Parameter(torch.Tensor(num_features).uniform_())
+            self.beta = nn.Parameter(torch.zeros(num_features))
+
+    def forward(self, x):
+        shape = [-1] + [1] * (x.dim() - 1)
+        mean = x.view(x.size(0), -1).mean(1).view(*shape)
+        std = x.view(x.size(0), -1).std(1).view(*shape)
+
+        y = (x - mean) / (std + self.eps)
+        if self.affine:
+            shape = [1, -1] + [1] * (x.dim() - 2)
+            y = self.gamma.view(*shape) * y + self.beta.view(*shape)
+        return y
+
+nn.LayerNorm = LayerNorm
+
 
 class Actor(nn.Module):
-
     def __init__(self, hidden_size, num_inputs, action_space):
         super(Actor, self).__init__()
         self.action_space = action_space
         num_outputs = action_space.shape[0]
 
-        self.bn0 = nn.BatchNorm1d(num_inputs)
-        self.bn0.weight.data.fill_(1)
-        self.bn0.bias.data.fill_(0)
-
         self.linear1 = nn.Linear(num_inputs, hidden_size)
-        self.bn1 = nn.BatchNorm1d(hidden_size)
-        self.bn1.weight.data.fill_(1)
-        self.bn1.bias.data.fill_(0)
+        self.ln1 = nn.LayerNorm(hidden_size)
 
         self.linear2 = nn.Linear(hidden_size, hidden_size)
-        self.bn2 = nn.BatchNorm1d(hidden_size)
-        self.bn2.weight.data.fill_(1)
-        self.bn2.bias.data.fill_(0)
+        self.ln2 = nn.LayerNorm(hidden_size)
 
         self.mu = nn.Linear(hidden_size, num_outputs)
         self.mu.weight.data.mul_(0.1)
         self.mu.bias.data.mul_(0.1)
 
-
     def forward(self, inputs):
         x = inputs
-        x = self.bn0(x)
-        x = F.tanh(self.linear1(x))
-        x = F.tanh(self.linear2(x))
-
+        x = self.linear1(x)
+        x = self.ln1(x)
+        x = F.relu(x)
+        x = self.linear2(x)
+        x = self.ln2(x)
+        x = F.relu(x)
         mu = F.tanh(self.mu(x))
         return mu
 
-    
 class Critic(nn.Module):
-
     def __init__(self, hidden_size, num_inputs, action_space):
         super(Critic, self).__init__()
         self.action_space = action_space
         num_outputs = action_space.shape[0]
-        self.bn0 = nn.BatchNorm1d(num_inputs)
-        self.bn0.weight.data.fill_(1)
-        self.bn0.bias.data.fill_(0)
 
         self.linear1 = nn.Linear(num_inputs, hidden_size)
-        self.bn1 = nn.BatchNorm1d(hidden_size)
-        self.bn1.weight.data.fill_(1)
-        self.bn1.bias.data.fill_(0)
+        self.ln1 = nn.LayerNorm(hidden_size)
 
-        self.linear_action = nn.Linear(num_outputs, hidden_size)
-        self.bn_a = nn.BatchNorm1d(hidden_size)
-        self.bn_a.weight.data.fill_(1)
-        self.bn_a.bias.data.fill_(0)
-
-        self.linear2 = nn.Linear(hidden_size + hidden_size, hidden_size)
-        self.bn2 = nn.BatchNorm1d(hidden_size)
-        self.bn2.weight.data.fill_(1)
-        self.bn2.bias.data.fill_(0)
+        self.linear2 = nn.Linear(hidden_size+num_outputs, hidden_size)
+        self.ln2 = nn.LayerNorm(hidden_size)
 
         self.V = nn.Linear(hidden_size, 1)
         self.V.weight.data.mul_(0.1)
@@ -85,15 +93,16 @@ class Critic(nn.Module):
 
     def forward(self, inputs, actions):
         x = inputs
-        x = self.bn0(x)
-        x = F.tanh(self.linear1(x))
-        a = F.tanh(self.linear_action(actions))
-        x = torch.cat((x, a), 1)
-        x = F.tanh(self.linear2(x))
+        x = self.linear1(x)
+        x = self.ln1(x)
+        x = F.relu(x)
 
+        x = torch.cat((x, actions), 1)
+        x = self.linear2(x)
+        x = self.ln2(x)
+        x = F.relu(x)
         V = self.V(x)
         return V
-
 
 class DDPG(object):
     def __init__(self, gamma, tau, hidden_size, num_inputs, action_space):
@@ -103,6 +112,7 @@ class DDPG(object):
 
         self.actor = Actor(hidden_size, self.num_inputs, self.action_space)
         self.actor_target = Actor(hidden_size, self.num_inputs, self.action_space)
+        self.actor_perturbed = Actor(hidden_size, self.num_inputs, self.action_space)
         self.actor_optim = Adam(self.actor.parameters(), lr=1e-4)
 
         self.critic = Critic(hidden_size, self.num_inputs, self.action_space)
@@ -116,14 +126,18 @@ class DDPG(object):
         hard_update(self.critic_target, self.critic)
 
 
-    def select_action(self, state, exploration=None):
+    def select_action(self, state, action_noise=None, param_noise=None):
         self.actor.eval()
-        with torch.no_grad():
+        if param_noise is not None: 
+            mu = self.actor_perturbed((Variable(state)))
+        else:
             mu = self.actor((Variable(state)))
+
         self.actor.train()
         mu = mu.data
-        if exploration is not None:
-            mu += torch.Tensor(exploration.noise())
+
+        if action_noise is not None:
+            mu += torch.Tensor(action_noise.noise())
 
         return mu.clamp(-1, 1)
 
@@ -133,8 +147,7 @@ class DDPG(object):
         action_batch = Variable(torch.cat(batch.action))
         reward_batch = Variable(torch.cat(batch.reward))
         mask_batch = Variable(torch.cat(batch.mask))
-        with torch.no_grad():
-            next_state_batch = Variable(torch.cat(batch.next_state))
+        next_state_batch = Variable(torch.cat(batch.next_state))
         
         next_action_batch = self.actor_target(next_state_batch)
         next_state_action_values = self.critic_target(next_state_batch, next_action_batch)
@@ -160,3 +173,32 @@ class DDPG(object):
 
         soft_update(self.actor_target, self.actor, self.tau)
         soft_update(self.critic_target, self.critic, self.tau)
+
+    def perturb_actor_parameters(self, param_noise):
+        """Apply parameter noise to actor model, for exploration"""
+        hard_update(self.actor_perturbed, self.actor)
+        params = self.actor_perturbed.state_dict()
+        for name in params:
+            if 'ln' in name: 
+                pass 
+            param = params[name]
+            param += torch.randn(param.shape) * param_noise.current_stddev
+
+    def save_model(self, env_name, suffix="", actor_path=None, critic_path=None):
+        if not os.path.exists('models/'):
+            os.makedirs('models/')
+
+        if actor_path is None:
+            actor_path = "models/ddpg_actor_{}_{}".format(env_name, suffix) 
+        if critic_path is None:
+            critic_path = "models/ddpg_critic_{}_{}".format(env_name, suffix) 
+        print('Saving models to {} and {}'.format(actor_path, critic_path))
+        torch.save(self.actor.state_dict(), actor_path)
+        torch.save(self.critic.state_dict(), critic_path)
+
+    def load_model(self, actor_path, critic_path):
+        print('Loading models from {} and {}'.format(actor_path, critic_path))
+        if actor_path is not None:
+            self.actor.load_state_dict(torch.load(actor_path))
+        if critic_path is not None: 
+            self.critic.load_state_dict(torch.load(critic_path))

--- a/param_noise.py
+++ b/param_noise.py
@@ -1,0 +1,51 @@
+import numpy as np
+import torch
+from math import sqrt
+
+"""
+From OpenAI Baselines:
+https://github.com/openai/baselines/blob/master/baselines/ddpg/noise.py
+"""
+class AdaptiveParamNoiseSpec(object):
+    def __init__(self, initial_stddev=0.1, desired_action_stddev=0.2, adaptation_coefficient=1.01):
+        """
+        Note that initial_stddev and current_stddev refer to std of parameter noise, 
+        but desired_action_stddev refers to (as name notes) desired std in action space
+        """
+        self.initial_stddev = initial_stddev
+        self.desired_action_stddev = desired_action_stddev
+        self.adaptation_coefficient = adaptation_coefficient
+
+        self.current_stddev = initial_stddev
+
+    def adapt(self, distance):
+        if distance > self.desired_action_stddev:
+            # Decrease stddev.
+            self.current_stddev /= self.adaptation_coefficient
+        else:
+            # Increase stddev.
+            self.current_stddev *= self.adaptation_coefficient
+
+    def get_stats(self):
+        stats = {
+            'param_noise_stddev': self.current_stddev,
+        }
+        return stats
+
+    def __repr__(self):
+        fmt = 'AdaptiveParamNoiseSpec(initial_stddev={}, desired_action_stddev={}, adaptation_coefficient={})'
+        return fmt.format(self.initial_stddev, self.desired_action_stddev, self.adaptation_coefficient)
+
+def ddpg_distance_metric(actions1, actions2):
+    """
+    Compute "distance" between actions taken by two policies at the same states
+    Expects numpy arrays
+    """
+    diff = actions1-actions2
+    mean_diff = np.mean(np.square(diff), axis=0)
+    dist = sqrt(np.mean(mean_diff))
+    return dist
+
+
+
+


### PR DESCRIPTION
I implemented parameter noise for DDPG, as described here: https://blog.openai.com/better-exploration-with-parameter-noise/ 

I found that the trained policies resulting from DDPG with OU noise were similar to the one shown in the blog post above; the agent flipped onto its head and scooted forward, with the reward plateauing around 1000. With parameter noise, the learned policy looked more like running and ended with rewards of 3000+. 

I modified the policy network architecture for DDPG to include layernorm, which is necessary for using parameter noise. 

Parameter noise is not implemented yet for NAF, because I am not too familiar with the algorithm. The only change in the NAF code is an extra argument to `select_action` to make the interface the same as DDPG’s. 

I also added utility functions for saving and loading networks.

To-do: decay parameter noise like how it’s done for OU noise