### PR TITLE
fixed NAF reward discount

### DIFF
--- a/naf.py
+++ b/naf.py
@@ -118,7 +118,7 @@ class NAF:
 
         reward_batch = reward_batch.unsqueeze(1)
         mask_batch = mask_batch.unsqueeze(1)
-        expected_state_action_values = reward_batch + (self.gamma * mask_batch + next_state_values)
+        expected_state_action_values = reward_batch + (self.gamma * mask_batch * next_state_values)
 
         _, state_action_values, _ = self.model((state_batch, action_batch))
 


### PR DESCRIPTION
Hi Ilya,

Thanks for your open-source implementation of DDPG/NAF in pytorch. 

We spotted a typo in NAF: the discount factor (and the done mask) should multiply the next_state_values instead of adding up to it.

Cheers,
Jacques