### PR TITLE
fixes typo. There is no actor_path in naf, changed it to model_path

### DIFF
--- a/naf.py
+++ b/naf.py
@@ -139,7 +139,7 @@ class NAF:
 
         if model_path is None:
             model_path = "models/naf_{}_{}".format(env_name, suffix) 
-        print('Saving model to {}'.format(actor_path))
+        print('Saving model to {}'.format(model_path))
         torch.save(self.model.state_dict(), model_path)
 
     def load_model(self, model_path):


### PR DESCRIPTION
Typo: `actor_path` was undefined on the print message. Changed it to `model_path`.